### PR TITLE
VSCodeのカスタムカラーの設定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,11 @@
 	"[javascript]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
+	"workbench.colorCustomizations": {
+		"titleBar.activeBackground": "#a94745",
+		"titleBar.inactiveBackground": "#a94745",
+		"titleBar.activeForeground": "#ffffff"
+	},
 	"editor.formatOnSave": true,
 	"editor.tabSize": 2
 }


### PR DESCRIPTION
### やったこと
- 画面上部のバーに色を設定
  - a94745

### 備考
- 見分けつかなくてウィンドウ遷移しまくるのが面倒なので色つけたいなという
- こっちの色の方がいいなどあれば